### PR TITLE
Fixed pan move responder and added bounds for it

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,8 +144,19 @@ class SideMenu extends Component {
    * @return {Void}
    */
   handlePanResponderMove(e: Object, gestureState: Object) {
-    if (this.state.left.__getValue() * this.menuPositionMultiplier() >= 0) {
-      this.state.left.setValue(this.prevLeft + gestureState.dx);
+    const currentLeft = this.prevLeft + gestureState.dx;
+
+    let shouldPan = false;
+
+    if ((this.props.menuPosition === 'left' &&
+        (currentLeft >= 0 && currentLeft <= this.props.openMenuOffset)) ||
+        (this.props.menuPosition === 'right' &&
+        (currentLeft <= 0 && currentLeft >= -this.props.openMenuOffset))) {
+      shouldPan = true;
+    }
+
+    if (shouldPan) {
+      this.state.left.setValue(currentLeft);
     }
   }
 
@@ -329,6 +340,7 @@ SideMenu.defaultProps = {
   toleranceX: 10,
   edgeHitWidth: 60,
   touchToClose: false,
+  menuPosition: 'left',
   onStartShouldSetResponderCapture: () => true,
   onChange: () => {},
   animationStyle: (value) => {


### PR DESCRIPTION
#Cannot close menu by pan gesture... 
__gif__
![gif](https://dl.dropboxusercontent.com/u/59256228/pan_responder.gif)
__fixed version__
![fixed version](https://dl.dropboxusercontent.com/u/59256228/pan_responder_fix.gif)

I know. it was fixed, but why we give ability to pan frontview in out of range(right bound for left menu...)?