### PR TITLE
Stretching menu component with flex:1 style

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,11 +277,17 @@ class SideMenu extends Component {
   render() {
     let menu = null;
 
+    const {height} = this.state;
+
     /**
      * If menu is ready to be rendered
      */
     if (this.state.shouldRenderMenu) {
-      menu = <View style={styles.menu}>{this.props.menu}</View>;
+      menu = <View style={[
+          styles.menu,
+          {width: this.props.openMenuOffset || openMenuOffset},
+          {height},
+        ]}>{this.props.menu}</View>;
     }
 
     return (


### PR DESCRIPTION
If menu component passed with `flex: 1` style, it doesn't work... Flex needs to know `width` and `height` to work because styles.menu has `position:absolute`.

```javascript
render() {
  const menu = <View style={{backgroundColor: '#999', flex: 1}}></View>;
  return <SideMenu menu={menu} />;
}
```