### PR TITLE
isOpen prop should be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,6 +299,7 @@ SideMenu.propTypes = {
   animationFunction: React.PropTypes.func,
   onStartShouldSetResponderCapture: React.PropTypes.func,
   defaultOpen: React.PropTypes.bool,
+  isOpen: React.PropTypes.bool,
 };
 
 SideMenu.defaultProps = {
@@ -327,6 +328,7 @@ SideMenu.defaultProps = {
     );
   },
   defaultOpen: false,
+  isOpen: false,
 };
 
 module.exports = SideMenu;


### PR DESCRIPTION
isOpen prop should be optional, it's easier for manual state management (opposite to declarative state management).

When isOpen is not provided, it's undefined, it causes problem for below comparison.
```javascript
this.isOpen !== props.isOpen
```