### PR TITLE
Fix glitch with initial render

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ class SideMenu extends Component {
     this.prevLeft = 0;
 
     this.state = {
-      shouldRenderMenu: false,
+      width: deviceScreen.width,
+      height: deviceScreen.height,
       left: new Animated.Value(0),
     };
   }
@@ -67,7 +68,7 @@ class SideMenu extends Component {
       onPanResponderRelease: this.handlePanResponderEnd.bind(this),
     });
   }
-  
+
   componentWillReceiveProps(props) {
     if (this.isOpen !== props.isOpen) {
       this.toggleMenu();
@@ -75,11 +76,6 @@ class SideMenu extends Component {
   }
 
   componentDidMount() {
-    setTimeout(() => {
-      this.setState({
-        shouldRenderMenu: true,
-      });
-    }, 500);
     if (this.props.defaultOpen) {
       this.openMenu();
     }
@@ -275,14 +271,7 @@ class SideMenu extends Component {
    * @return {React.Component}
    */
   render() {
-    let menu = null;
-
-    /**
-     * If menu is ready to be rendered
-     */
-    if (this.state.shouldRenderMenu) {
-      menu = <View style={styles.menu}>{this.props.menu}</View>;
-    }
+    const menu = <View style={styles.menu}>{this.props.menu}</View>;
 
     return (
       <View style={styles.container} onLayout={this.onLayoutChange.bind(this)}>


### PR DESCRIPTION
This is a regression introduced in https://github.com/react-native-fellowship/react-native-side-menu/commit/601cbe9d1333273fc829bf38475bee1f5487ab14 because of two things:

1. onLayout is called (according to documentation), immediately once the layout has been calculated,
but the new layout **may not yet be reflected on the screen** at the time the event is received,
**especially if a layout animation is in progress**.
2. State is missing initial width & height properties meaning contentView has no dimensions defined at mount and defaults to calculated ones (because of `flex: 1` which obviously will change after first callback is called)

We have managed to workaround that issue by adding setTimeout so that the points 1 & 2 were temporarily hidden.

The purpose of onLayout was to recalculate width/height on orientation change, not on initialRender as well.

Thanks to these changes, the glitch with initialRender no longer exists.