### PR TITLE
Better props

### DIFF
--- a/examples/Basic/Basic.js
+++ b/examples/Basic/Basic.js
@@ -69,7 +69,13 @@ module.exports = class Basic extends Component {
     });
   }
 
-  updateMenuState(isOpen) {
+  toggleMenu() {
+    this.setState({
+      isOpen: !this.state.isOpen,
+    });
+  }
+
+  handleMenuSwipe(isOpen) {
     this.setState({ isOpen, });
   }
 
@@ -78,7 +84,8 @@ module.exports = class Basic extends Component {
       <SideMenu
         menu={<Menu />}
         isOpen={this.state.isOpen}
-        onChange={(isOpen) => this.updateMenuState(isOpen)}>
+        onSwipe={isOpen => this.handleMenuSwipe(isOpen)}
+        onBackDropPressed={() => this.toggleMenu()}>
         <View style={styles.container}>
           <Text style={styles.welcome}>
             Welcome to React Native!


### PR DESCRIPTION
This pull request rewrites `props-driven` feature we have implemented in the past. Somehow I wasn't happy with it because we were still using forceUpdate and keeping `this.isOpen` property. We were only respecting props changes and sending `onChange` event - that was quite confusing.

This is more an idea that needs to be discussed, but it essentially fixes above issues plus it removes disableGeastures in favour of `onSwipe` method, that is used to handle gesture changes now.