### PR TITLE
Describe why `scrollsToTop` does not work sometimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class Application extends React.Component {
 
 #### ScrollView does not scroll to top on status bar press
 
-This is related to the iOS way of handling `scrollsToTop`. When there are multiple ScrollViews with that property enabled in the same `<View>` - it will stop working. Simply set `scrollsToTop={false}` on your ScrollView inside `Menu` component to get the other one (in your Content component) working.
+On iPhone, the scroll-to-top gesture has no effect if there is more than one scroll view on-screen that has scrollsToTop set to true. Since it defaults to `true` in ReactNative, you have to set `scrollsToTop={false}` on your ScrollView inside `Menu` component in order to get it working as desired.
 
 ### Questions?
 Feel free to contact me in [twitter](https://twitter.com/kureevalexey) or [create an issue](https://github.com/Kureev/react-native-side-menu/issues/new)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class Application extends React.Component {
 
 #### ScrollView does not scroll to top on status bar press
 
-This is related to the iOS way of handling `scrollsToTop`. When there are multiple ScrollViews with that property enabled in the same in the same `<View>` - it will stop working. Simply set `scrollsToTop={false}` on your `Menu` component.
+This is related to the iOS way of handling `scrollsToTop`. When there are multiple ScrollViews with that property enabled in the same `<View>` - it will stop working. Simply set `scrollsToTop={false}` on your ScrollView inside `Menu` component to get the other one (in your Content component) working.
 
 ### Questions?
 Feel free to contact me in [twitter](https://twitter.com/kureevalexey) or [create an issue](https://github.com/Kureev/react-native-side-menu/issues/new)

--- a/README.md
+++ b/README.md
@@ -68,5 +68,11 @@ class Application extends React.Component {
 - `animationStyle` (Function -> Object) - Function that accept 1 argument (value) and return an object:
   - `value` you should use at the place you need current value of animated parameter (left offset of content view)
 
+### FAQ
+
+#### ScrollView does not scroll to top on status bar press
+
+This is related to the iOS way of handling `scrollsToTop`. When there are multiple ScrollViews with that property enabled in the same in the same `<View>` - it will stop working. Simply set `scrollsToTop={false}` on your `Menu` component.
+
 ### Questions?
 Feel free to contact me in [twitter](https://twitter.com/kureevalexey) or [create an issue](https://github.com/Kureev/react-native-side-menu/issues/new)

--- a/examples/Basic/Menu.js
+++ b/examples/Basic/Menu.js
@@ -45,7 +45,7 @@ const styles = StyleSheet.create({
 module.exports = class Menu extends Component {
   render() {
     return (
-      <ScrollView style={styles.menu}>
+      <ScrollView scrollsToTop={false} style={styles.menu}>
         <View style={styles.avatarContainer}>
           <Image
             style={styles.avatar}


### PR DESCRIPTION
Fixes #163 

https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIScrollView_Class/index.html#//apple_ref/occ/instp/UIScrollView/scrollsToTop

> On iPhone, the scroll-to-top gesture has no effect if there is more than one scroll view on-screen that has scrollsToTop set to YES.