### PR TITLE
Fixed styles so longer scrollviews stay within the bounds of the screen

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -16,6 +16,8 @@ module.exports = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
+    right: 0,
+    bottom: 0
   },
   frontView: {
     flex: 1,


### PR DESCRIPTION
Earlier, without the right and bottom margins, if the view had a scrollview with `flex: 1`, it would go out of bounds of the screen. Adding these values will confine it within the bounds.