### PR TITLE
Ensure that menu takes all available space

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ class SideMenu extends Component {
    * @return {React.Component}
    */
   render() {
-    const menu = <View style={styles.menu}>{this.props.menu}</View>;
+    const menu = <View style={[styles.menu, {right: deviceScreen.width - this.props.openMenuOffset}]}>{this.props.menu}</View>;
 
     return (
       <View style={styles.container} onLayout={this.onLayoutChange.bind(this)}>

--- a/styles.js
+++ b/styles.js
@@ -4,18 +4,21 @@ const {
   StyleSheet,
 } = React;
 
-module.exports = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  menu: {
-    flex: 1,
-    backgroundColor: 'transparent',
+const absoluteStretch = {
     position: 'absolute',
     top: 0,
     left: 0,
+    bottom: 0,
+    right: 0,
+};
+
+module.exports = StyleSheet.create({
+  container: {
+    ...absoluteStretch,
+    justifyContent: 'center',
+  },
+  menu: {
+    ...absoluteStretch,
   },
   frontView: {
     flex: 1,
@@ -25,11 +28,7 @@ module.exports = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   overlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
+    ...absoluteStretch,
     backgroundColor: 'transparent',
   },
 });


### PR DESCRIPTION
Without this it was not possible to use `{flex:1}` in the menu component.

More specifically I tried to use use ScrollView with a fixed footer in the menu.