### PR TITLE
customize elements you don't want to respond on swipe

### DIFF
--- a/examples/Basic/Basic.js
+++ b/examples/Basic/Basic.js
@@ -63,6 +63,7 @@ module.exports = class Basic extends Component {
     isOpen: false,
     selectedItem: 'About',
   };
+  skippedElements = [];
 
   toggle() {
     this.setState({
@@ -88,7 +89,8 @@ module.exports = class Basic extends Component {
       <SideMenu
         menu={menu}
         isOpen={this.state.isOpen}
-        onChange={(isOpen) => this.updateMenuState(isOpen)}>
+        onChange={(isOpen) => this.updateMenuState(isOpen)}
+        ref={(ref)=> {if (ref !== null) ref.skippedElements = this.skippedElements;}}>
         <View style={styles.container}>
           <Text style={styles.welcome}>
             Welcome to React Native!
@@ -102,6 +104,14 @@ module.exports = class Basic extends Component {
           </Text>
           <Text style={styles.instructions}>
             Current selected menu item is: {this.state.selectedItem}
+          </Text>
+          <Text
+            ref={(ref)=> {if (ref !== null) this.skippedElements.push(ref._reactInternalInstance._rootNodeID);}}
+            style={[styles.instructions, {borderWidth: 1, marginTop: 30}]}>
+            And this is an example of element (TEXT element to be honest), which
+            will not respond to any swipes to show the menu back. It should, because
+            `props.edgeHitWidth` is set to `deviceScreen.width`, but it won't :) Sometimes
+            it may be really usefull, for example, in horizontal scroll views.
           </Text>
         </View>
         <Button style={styles.button} onPress={() => this.toggle()}>

--- a/index.js
+++ b/index.js
@@ -88,6 +88,13 @@ class SideMenu extends Component {
    */
   handleMoveShouldSetPanResponder(e: Object, gestureState: Object) {
     if (this.gesturesAreEnabled()) {
+      var rootId = e['dispatchMarker'];
+      var elemsToSkip = 0;
+      this.skippedElements.forEach((elem, index, arr)=> {
+        if (rootId.indexOf(elem) > -1) elemsToSkip++;
+      });
+      if (elemsToSkip) return false;
+
       const x = Math.round(Math.abs(gestureState.dx));
       const y = Math.round(Math.abs(gestureState.dy));
 
@@ -240,7 +247,7 @@ SideMenu.propTypes = {
 SideMenu.defaultProps = {
   toleranceY: 10,
   toleranceX: 10,
-  edgeHitWidth: 60,
+  edgeHitWidth: deviceScreen.width,
   openMenuOffset: deviceScreen.width * 2 / 3,
   hiddenMenuOffset: 0,
   onStartShouldSetResponderCapture: () => true,


### PR DESCRIPTION
Sometimes it's useful to specify elements you don't want to reply on your swipe actions to show the menu. For example, I use it when I have horizontal scroll view on my content view, and `edgeHitWidth` is set to `deviceScreen.width` to make it possible to show left menu via swiping to the right in every point you want, except the given element(s).