### PR TITLE
added maxDraggingOffset property

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ class Application extends React.Component {
 - `menu` (React.Component) - Menu component
 - `isOpen` (Boolean) - Props driven control over menu open state
 - `openMenuOffset` (Number) - Content view left margin if menu is opened, defaults to 2/3 of device screen width
+- `maxDraggingOffset` (Number) - Maximum dragging possible in addiction to the menu size, default 0 that means that the user can drag only until the full menu is shown, to change if a different behaviour is wanted
 - `hiddenMenuOffset` (Number) - Content view left margin if menu is hidden
 - `edgeHitWidth` (Number) - Edge distance on content view to open side menu, defaults to 60
 - `toleranceX` (Number) - X axis tolerance

--- a/index.js
+++ b/index.js
@@ -120,6 +120,10 @@ class SideMenu extends Component {
     if (this.state.left.__getValue() * this.menuPositionMultiplier() >= 0) {
       let newLeft = this.prevLeft + gestureState.dx;
 
+      if (newLeft > this.props.openMenuOffset + this.props.maxDraggingOffset) {
+        newLeft = this.props.openMenuOffset + this.props.maxDraggingOffset;
+      }
+
       if (!this.props.bounceBackOnOverdraw && Math.abs(newLeft) > this.props.openMenuOffset) {
         newLeft = this.menuPositionMultiplier() * this.props.openMenuOffset;
       }
@@ -236,6 +240,7 @@ SideMenu.propTypes = {
   menuPosition: React.PropTypes.oneOf(['left', 'right', ]),
   onChange: React.PropTypes.func,
   openMenuOffset: React.PropTypes.number,
+  maxDraggingOffset: React.PropTypes.number,
   hiddenMenuOffset: React.PropTypes.number,
   disableGestures: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.bool, ]),
   animationFunction: React.PropTypes.func,
@@ -249,6 +254,7 @@ SideMenu.defaultProps = {
   toleranceX: 10,
   edgeHitWidth: 60,
   openMenuOffset: deviceScreen.width * 2 / 3,
+  maxDraggingOffset: 0,
   hiddenMenuOffset: 0,
   onStartShouldSetResponderCapture: () => true,
   onChange: () => {},


### PR DESCRIPTION
added maxDraggingOffset property to set the maximum value for the dragging gesture. 
To avoid that the user can drag more than the menu size and show a white unwanted background.
By default set to 0 so that the user can drag only until the full menu is shown, but settable in case that dragging behaviour should be like before.